### PR TITLE
Update precision formatting insimple_end_to_end_demo.ipynb

### DIFF
--- a/examples/simple_end_to_end_demo.ipynb
+++ b/examples/simple_end_to_end_demo.ipynb
@@ -392,7 +392,7 @@
         }
       ],
       "source": [
-        "correlations[0].style.background_gradient(cmap='RdBu', vmin=-1, vmax=1).set_precision(3)"
+        "correlations[0].style.format('{:.3f}').background_gradient(cmap='RdBu', vmin=-1, vmax=1)
       ]
     },
     {


### PR DESCRIPTION
Precision formatting was done using an outdated method causing an error in pandas.