### PR TITLE
fix: align xticks in barplot with multiple labels for budget compare …

### DIFF
--- a/lightweight_mmm/plot.py
+++ b/lightweight_mmm/plot.py
@@ -971,7 +971,7 @@ def plot_pre_post_budget_allocation_comparison(
         textcoords="offset points")
 
   axes[0].set_xticks(x_axis)
-  axes[0].set_xticklabels(channel_names, fontsize="medium")
+  axes[0].set_xticklabels(channel_names, fontsize="medium", rotation=60, ha="right", rotation_mode="anchor")
   axes[0].legend(fontsize="medium")
 
   plots3 = axes[1].bar([


### PR DESCRIPTION
This PR fixes the alignment for compare budget when there are multiple labels

### Before
<img width="1183" alt="Screenshot 2023-10-18 at 08 55 49" src="https://github.com/google/lightweight_mmm/assets/20767068/97981f9e-216c-43e2-9586-539907fb02fb">

### After
<img width="1183" alt="Screenshot 2023-10-18 at 08 56 00" src="https://github.com/google/lightweight_mmm/assets/20767068/75ab8220-5742-4103-9525-7db7ff12d0cb">
