### PR TITLE
adding a new flavour of model which is hill_carryover

### DIFF
--- a/lightweight_mmm/lightweight_mmm.py
+++ b/lightweight_mmm/lightweight_mmm.py
@@ -64,7 +64,8 @@ Prior = Union[
 _NAMES_TO_MODEL_TRANSFORMS = immutabledict.immutabledict({
     "hill_adstock": models.transform_hill_adstock,
     "adstock": models.transform_adstock,
-    "carryover": models.transform_carryover
+    "carryover": models.transform_carryover,
+    "hill_carryover": models.transform_hill_carryover
 })
 _MODEL_FUNCTION = models.media_mix_model
 


### PR DESCRIPTION
The pull request implements a new variant of the model("hill_carryover") which applies saturation on top of carryover formulation of model. This implementation aligns with the paper 
[([Jin, Y., Wang, Y., Sun, Y., Chan, D., & Koehler, J. (2017). Bayesian Methods for Media Mix Modeling with Carryover and Shape Effects. Google Inc.](https://research.google/pubs/pub46001/))]